### PR TITLE
adjust config to ensure double quotes in JSX

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "prettier.trailingComma": "es5",
-  "prettier.singleQuote": true
+  "prettier.singleQuote": true,
+  "prettier.jsxSingleQuote": false
 }

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -29,6 +29,7 @@ module.exports = {
   plugins: ['react'],
   rules: {
     quotes: ['error', 'single'],
+    'jsx-quotes': ['error', 'prefer-double'],
     'no-console': 'error',
   },
   settings: {


### PR DESCRIPTION
In JSX, the convention is to use double quotes for JSX attributes, similar to how HTML uses double quotes for attributes. To ensure double quotes are used in JSX, we adjust both Prettier and ESLint configs.