### PR TITLE
Implement AddTaskForm Component

### DIFF
--- a/client/src/components/!ComponentFolderStructureTemplate/Component.jsx
+++ b/client/src/components/!ComponentFolderStructureTemplate/Component.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import TEST_ID from './Component.testid';
+
+const Component = () => {
+  return <div data-testid={TEST_ID.element}></div>;
+};
+
+export default Component;

--- a/client/src/components/!ComponentFolderStructureTemplate/Component.testid.js
+++ b/client/src/components/!ComponentFolderStructureTemplate/Component.testid.js
@@ -1,0 +1,7 @@
+import createTestIdFilePath from '../../utils/createTestIdFilePath';
+
+const TEST_ID = {
+  element: `${createTestIdFilePath('components', 'Component')}-element`,
+};
+
+export default TEST_ID;

--- a/client/src/components/!ComponentFolderStructureTemplate/__tests__/Component.test.js
+++ b/client/src/components/!ComponentFolderStructureTemplate/__tests__/Component.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Component from '../Component';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TEST_ID from '../Component.testid';
+
+describe('Component', () => {
+  it('renders the Component component', () => {
+    render(
+      <MemoryRouter>
+        <Component toggleLeftSideMenu={() => {}} />
+      </MemoryRouter>
+    );
+
+    // Assert that the component is rendered
+    const componentElement = screen.getByTestId(TEST_ID.element);
+    expect(componentElement).toBeInTheDocument();
+  });
+});

--- a/client/src/components/!ComponentFolderStructureTemplate/__tests__/Component.test.js
+++ b/client/src/components/!ComponentFolderStructureTemplate/__tests__/Component.test.js
@@ -8,7 +8,7 @@ describe('Component', () => {
   it('renders the Component component', () => {
     render(
       <MemoryRouter>
-        <Component toggleLeftSideMenu={() => {}} />
+        <Component />
       </MemoryRouter>
     );
 

--- a/client/src/components/AddTaskButton/AddTaskButton.jsx
+++ b/client/src/components/AddTaskButton/AddTaskButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AddTaskIcon from '../../assets/add-task.SVG'; // Import the SVG file
+import AddTaskIcon from '../../assets/add-task.svg';
 
 const AddTaskButton = () => {
   const handleClick = () => {

--- a/client/src/components/AddTaskForm/AddTaskForm.jsx
+++ b/client/src/components/AddTaskForm/AddTaskForm.jsx
@@ -1,8 +1,123 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import TEST_ID from './AddTaskForm.testid';
 
+const styles = {
+  container:
+    'w-full border border-solid border-organizerGray flex flex-col min-h-0',
+  form: 'm-3 flex flex-col space-y-4 overflow-hidden max-h-[80vh]',
+  nameInput: 'w-full focus:outline-none',
+  description: 'w-full focus:outline-none resize-none min-h-0',
+  buttonRow: 'flex space-x-2 ',
+  areaRow: 'flex justify-between',
+  areaSelector: 'border px-2 py-1 border-solid border-organizerGray',
+  closeButton:
+    'mr-2 px-2 py-1 inline-block border border-solid border-organizerGray',
+  sendButton: 'inline-block px-2 py-1 border border-solid border-organizerGray',
+  dueDate: 'border px-2 py-1 border-solid border-organizerGray',
+  colourSelector: 'border px-2 py-1 border-solid border-organizerGray',
+};
+
 const AddTaskForm = () => {
-  return <div data-testid={TEST_ID.element}></div>;
+  const [taskName, setTaskName] = useState('');
+  const [description, setDescription] = useState('');
+  const [area, setArea] = useState('Inbox');
+
+  const formRef = useRef(null);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (formRef.current) {
+        const formTop = formRef.current.getBoundingClientRect().top;
+        const availableHeight = window.innerHeight - formTop;
+        formRef.current.style.maxHeight = `${availableHeight * 0.95}px`;
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  // Overfill
+  const textAreaRef = useRef(null);
+  useEffect(() => {
+    textAreaRef.current.style.height = 'inherit';
+    const scrollHeight = textAreaRef.current.scrollHeight;
+    textAreaRef.current.style.height = `${scrollHeight}px`;
+  }, [description]);
+
+  return (
+    <div className={styles.container} data-testid={TEST_ID.container}>
+      <form ref={formRef} className={styles.form} data-testid={TEST_ID.form}>
+        <input
+          type="text"
+          value={taskName}
+          onChange={(e) => setTaskName(e.target.value)}
+          placeholder="Task name"
+          className={styles.nameInput}
+          data-testid={TEST_ID.nameInput}
+        />
+        <textarea
+          ref={textAreaRef}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+          style={{ minHeight: '20px', maxHeight: '100vh', overflow: 'auto' }}
+          className={styles.description}
+          data-testid={TEST_ID.description}
+        />
+        <div className={styles.buttonRow}>
+          <button
+            type="button"
+            onClick={() => {}}
+            className={styles.dueDate}
+            data-testid={TEST_ID.dueDateSelector}
+          >
+            Due date
+          </button>
+          <button
+            type="button"
+            onClick={() => {}}
+            className={styles.colourSelector}
+            data-testid={TEST_ID.colourSelector}
+          >
+            Colour
+          </button>
+        </div>
+        <div className={styles.areaRow}>
+          <select
+            value={area}
+            onChange={(e) => setArea(e.target.value)}
+            className={styles.areaSelector}
+            data-testid={TEST_ID.areaSelector}
+          >
+            <option value="Inbox">Inbox</option>
+            {/* Add other areas */}
+          </select>
+          <div>
+            <button
+              type="button"
+              onClick={() => {}}
+              className={styles.closeButton}
+              data-testid={TEST_ID.closeButton}
+            >
+              Close
+            </button>
+            <button
+              type="submit"
+              className={styles.sendButton}
+              data-testid={TEST_ID.sendButton}
+            >
+              Send
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
 };
 
 export default AddTaskForm;

--- a/client/src/components/AddTaskForm/AddTaskForm.jsx
+++ b/client/src/components/AddTaskForm/AddTaskForm.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import TEST_ID from './AddTaskForm.testid';
+
+const AddTaskForm = () => {
+  return <div data-testid={TEST_ID.element}></div>;
+};
+
+export default AddTaskForm;

--- a/client/src/components/AddTaskForm/AddTaskForm.jsx
+++ b/client/src/components/AddTaskForm/AddTaskForm.jsx
@@ -96,6 +96,9 @@ const AddTaskForm = () => {
           >
             <option value="Inbox">Inbox</option>
             {/* Add other areas */}
+            <option value="Area1">Area1</option>
+            <option value="Area2">Area2</option>
+            <option value="Area3">Area3</option>
           </select>
           <div>
             <button

--- a/client/src/components/AddTaskForm/AddTaskForm.testid.js
+++ b/client/src/components/AddTaskForm/AddTaskForm.testid.js
@@ -1,0 +1,7 @@
+import createTestIdFilePath from '../../utils/createTestIdFilePath';
+
+const TEST_ID = {
+  element: `${createTestIdFilePath('components', 'AddTaskForm')}-element`,
+};
+
+export default TEST_ID;

--- a/client/src/components/AddTaskForm/AddTaskForm.testid.js
+++ b/client/src/components/AddTaskForm/AddTaskForm.testid.js
@@ -1,7 +1,15 @@
 import createTestIdFilePath from '../../utils/createTestIdFilePath';
 
 const TEST_ID = {
-  element: `${createTestIdFilePath('components', 'AddTaskForm')}-element`,
+  container: `${createTestIdFilePath('components', 'AddTaskForm')}-container`,
+  form: `${createTestIdFilePath('components', 'AddTaskForm')}-form`,
+  nameInput: `${createTestIdFilePath('components', 'AddTaskForm')}-nameInput`,
+  description: `${createTestIdFilePath('components', 'AddTaskForm')}-description`,
+  dueDateSelector: `${createTestIdFilePath('components', 'AddTaskForm')}-dueDateSelector`,
+  colourSelector: `${createTestIdFilePath('components', 'AddTaskForm')}-colourSelector`,
+  areaSelector: `${createTestIdFilePath('components', 'AddTaskForm')}-areaSelector`,
+  closeButton: `${createTestIdFilePath('components', 'AddTaskForm')}-closeButton`,
+  sendButton: `${createTestIdFilePath('components', 'AddTaskForm')}-sendButton`,
 };
 
 export default TEST_ID;

--- a/client/src/components/AddTaskForm/__tests__/AddTaskForm.test.js
+++ b/client/src/components/AddTaskForm/__tests__/AddTaskForm.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import AddTaskForm from '../AddTaskForm';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TEST_ID from '../AddTaskForm.testid';
+
+describe('AddTaskForm', () => {
+  it('renders the AddTaskForm component', () => {
+    render(
+      <MemoryRouter>
+        <AddTaskForm toggleLeftSideMenu={() => {}} />
+      </MemoryRouter>
+    );
+
+    // Assert that the component is rendered
+    const AddTaskFormElement = screen.getByTestId(TEST_ID.element);
+    expect(AddTaskFormElement).toBeInTheDocument();
+  });
+});

--- a/client/src/components/AddTaskForm/__tests__/AddTaskForm.test.js
+++ b/client/src/components/AddTaskForm/__tests__/AddTaskForm.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import AddTaskForm from '../AddTaskForm';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import TEST_ID from '../AddTaskForm.testid';
 
@@ -42,6 +42,12 @@ describe('AddTaskForm', () => {
     const areaSelector = screen.getByTestId(TEST_ID.areaSelector);
     expect(areaSelector).toBeInTheDocument();
     expect(areaSelector).toHaveValue('Inbox');
+  });
+
+  it('changes area when a different option is selected', async () => {
+    const areaSelector = screen.getByTestId(TEST_ID.areaSelector);
+    fireEvent.change(areaSelector, { target: { value: 'Area2' } });
+    expect(areaSelector.value).toBe('Area2');
   });
 
   it('renders close button', () => {

--- a/client/src/components/AddTaskForm/__tests__/AddTaskForm.test.js
+++ b/client/src/components/AddTaskForm/__tests__/AddTaskForm.test.js
@@ -5,15 +5,52 @@ import { MemoryRouter } from 'react-router-dom';
 import TEST_ID from '../AddTaskForm.testid';
 
 describe('AddTaskForm', () => {
-  it('renders the AddTaskForm component', () => {
+  beforeEach(() => {
     render(
       <MemoryRouter>
-        <AddTaskForm toggleLeftSideMenu={() => {}} />
+        <AddTaskForm />
       </MemoryRouter>
     );
+  });
 
-    // Assert that the component is rendered
-    const AddTaskFormElement = screen.getByTestId(TEST_ID.element);
-    expect(AddTaskFormElement).toBeInTheDocument();
+  it('renders the AddTaskForm component', () => {
+    const container = screen.getByTestId(TEST_ID.container);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders task name input', () => {
+    const nameInput = screen.getByTestId(TEST_ID.nameInput);
+    expect(nameInput).toBeInTheDocument();
+  });
+
+  it('renders description textarea', () => {
+    const description = screen.getByTestId(TEST_ID.description);
+    expect(description).toBeInTheDocument();
+  });
+
+  it('renders due date selector', () => {
+    const dueDateSelector = screen.getByTestId(TEST_ID.dueDateSelector);
+    expect(dueDateSelector).toBeInTheDocument();
+  });
+
+  it('renders colour selector', () => {
+    const colourSelector = screen.getByTestId(TEST_ID.colourSelector);
+    expect(colourSelector).toBeInTheDocument();
+  });
+
+  it('renders area selector with default value as Inbox', () => {
+    const areaSelector = screen.getByTestId(TEST_ID.areaSelector);
+    expect(areaSelector).toBeInTheDocument();
+    expect(areaSelector).toHaveValue('Inbox');
+  });
+
+  it('renders close button', () => {
+    const closeButton = screen.getByTestId(TEST_ID.closeButton);
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('renders send button', () => {
+    const sendButton = screen.getByTestId(TEST_ID.sendButton);
+    expect(sendButton).toBeInTheDocument();
   });
 });

--- a/client/src/stories/!Component.stories.jsx
+++ b/client/src/stories/!Component.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Component from '../components/!ComponentFolderStructureTemplate/Component';
+import { MemoryRouter } from 'react-router-dom';
+
+export default {
+  title: 'Components/Component',
+  component: Component,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+const Template = (args) => <Component {...args} />;
+
+export const Default = Template.bind({});

--- a/client/src/stories/AddTaskForm.stories.jsx
+++ b/client/src/stories/AddTaskForm.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import AddTaskForm from '../components/AddTaskForm/AddTaskForm';
+import { MemoryRouter } from 'react-router-dom';
+
+export default {
+  title: 'Components/AddTaskForm',
+  component: AddTaskForm,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+const Template = (args) => <AddTaskForm {...args} />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
This PR introduces the `AddTaskForm` component, which allows users to add new tasks. The form includes the following elements:

- Task name input
- Description textarea
- Due date button
- Colour button
- Areas selector
- Close button
- Send button

The `Description` field is designed to occupy minimal vertical space by default but expands with the content. When the content overflows, the description becomes scrollable.

The `Areas` selector is set to `Inbox` by default.

At this stage, the buttons are not functional and are included for UI completeness.

The component also includes a `useEffect` hook to handle the resizing of the form and the textarea.

Unit tests have been added to ensure the component renders correctly and that the state changes when a different option is selected in the `Areas` selector.

#53 